### PR TITLE
鋳造タブ改善

### DIFF
--- a/src/interfaces/wallet.cpp
+++ b/src/interfaces/wallet.cpp
@@ -211,6 +211,11 @@ public:
         LOCK2(cs_main, m_wallet.cs_wallet);
         return m_wallet.IsLockedCoin(output.hash, output.n);
     }
+    bool isSpent(const uint256& hash, unsigned int n) override
+    {
+        LOCK2(cs_main, m_wallet.cs_wallet);
+        return m_wallet.IsSpent(hash, n);
+    }
     void listLockedCoins(std::vector<COutPoint>& outputs) override
     {
         LOCK2(cs_main, m_wallet.cs_wallet);

--- a/src/interfaces/wallet.h
+++ b/src/interfaces/wallet.h
@@ -128,6 +128,9 @@ public:
     //! Return whether coin is locked.
     virtual bool isLockedCoin(const COutPoint& output) = 0;
 
+    //! Return whether coin is Spent.
+    virtual bool isSpent(const uint256& hash, unsigned int n) = 0;
+
     //! List locked coins.
     virtual void listLockedCoins(std::vector<COutPoint>& outputs) = 0;
 

--- a/src/kernelrecord.cpp
+++ b/src/kernelrecord.cpp
@@ -50,10 +50,7 @@ vector<KernelRecord> KernelRecord::decomposeOutput(const interfaces::WalletTx& w
     for(uint32_t n = 0; n <= outs.size(); n++){
         if(isMine[n] == isminetype::ISMINE_SPENDABLE){
             int64_t nValue = outs[n].nValue;
-            CTxDestination address;
-            std::string addrStr;
-            ExtractDestination(outs[n].scriptPubKey, address);
-            addrStr = EncodeDestination(address);
+            std::string addrStr = EncodeDestination(wtx.txout_address[n]);
             parts.push_back(KernelRecord(hash, n, nTime, addrStr, nValue));
         }
     }

--- a/src/kernelrecord.cpp
+++ b/src/kernelrecord.cpp
@@ -23,22 +23,6 @@ bool KernelRecord::showTransaction()
 /*
  * Decompose CWallet transaction to model kernel records.
  */
-vector<KernelRecord> KernelRecord::decomposeOutput(const COutPoint& output, const interfaces::WalletTxOut& out)
-{
-    vector<KernelRecord> parts;
-    uint256 hash = output.hash;
-    uint32_t n = output.n;
-    int64_t nTime = out.time;
-    int64_t nValue = out.txout.nValue;
-    CTxDestination address;
-    std::string addrStr;
-    ExtractDestination(out.txout.scriptPubKey, address);
-    addrStr = EncodeDestination(address);
-
-    parts.push_back(KernelRecord(hash, n, nTime, addrStr, nValue));
-    return parts;
-}
-
 vector<KernelRecord> KernelRecord::decomposeOutput(const interfaces::WalletTx& wtx)
 {
     uint256 hash = wtx.tx->GetHash();

--- a/src/kernelrecord.cpp
+++ b/src/kernelrecord.cpp
@@ -46,7 +46,7 @@ vector<KernelRecord> KernelRecord::decomposeOutput(const interfaces::WalletTx& w
     std::vector<isminetype> isMine = wtx.txout_is_mine;
     vector<KernelRecord> parts;
     int64_t nTime = wtx.time;
-    
+
     for(uint32_t n = 0; n < outs.size(); n++){
         if(isMine[n] == isminetype::ISMINE_SPENDABLE){
             int64_t nValue = outs[n].nValue;

--- a/src/kernelrecord.cpp
+++ b/src/kernelrecord.cpp
@@ -47,7 +47,7 @@ vector<KernelRecord> KernelRecord::decomposeOutput(const interfaces::WalletTx& w
     vector<KernelRecord> parts;
     int64_t nTime = wtx.time;
     
-    for(uint32_t n = 0; n <= outs.size(); n++){
+    for(uint32_t n = 0; n < outs.size(); n++){
         if(isMine[n] == isminetype::ISMINE_SPENDABLE){
             int64_t nValue = outs[n].nValue;
             std::string addrStr = EncodeDestination(wtx.txout_address[n]);

--- a/src/kernelrecord.cpp
+++ b/src/kernelrecord.cpp
@@ -39,6 +39,27 @@ vector<KernelRecord> KernelRecord::decomposeOutput(const COutPoint& output, cons
     return parts;
 }
 
+vector<KernelRecord> KernelRecord::decomposeOutput(const interfaces::WalletTx& wtx)
+{
+    uint256 hash = wtx.tx->GetHash();
+    const std::vector<CTxOut> outs = wtx.tx->vout;
+    std::vector<isminetype> isMine = wtx.txout_is_mine;
+    vector<KernelRecord> parts;
+    int64_t nTime = wtx.time;
+    
+    for(uint32_t n = 0; n <= outs.size(); n++){
+        if(isMine[n] == isminetype::ISMINE_SPENDABLE){
+            int64_t nValue = outs[n].nValue;
+            CTxDestination address;
+            std::string addrStr;
+            ExtractDestination(outs[n].scriptPubKey, address);
+            addrStr = EncodeDestination(address);
+            parts.push_back(KernelRecord(hash, n, nTime, addrStr, nValue));
+        }
+    }
+    return parts;
+}
+
 std::string KernelRecord::getTxID()
 {
     return hash.ToString();

--- a/src/kernelrecord.cpp
+++ b/src/kernelrecord.cpp
@@ -35,7 +35,7 @@ vector<KernelRecord> KernelRecord::decomposeOutput(const interfaces::WalletTx& w
         if(isMine[n] == isminetype::ISMINE_SPENDABLE){
             int64_t nValue = outs[n].nValue;
             std::string addrStr = EncodeDestination(wtx.txout_address[n]);
-            parts.push_back(KernelRecord(hash, n, nTime, addrStr, nValue));
+            parts.emplace_back(hash, n, nTime, addrStr, nValue);
         }
     }
     return parts;

--- a/src/kernelrecord.h
+++ b/src/kernelrecord.h
@@ -31,7 +31,6 @@ public:
     }
 
     static bool showTransaction();
-    static std::vector<KernelRecord> decomposeOutput(const COutPoint& output, const interfaces::WalletTxOut& out);
     static std::vector<KernelRecord> decomposeOutput(const interfaces::WalletTx& wtx);
 
     uint256 hash;

--- a/src/kernelrecord.h
+++ b/src/kernelrecord.h
@@ -32,7 +32,7 @@ public:
 
     static bool showTransaction();
     static std::vector<KernelRecord> decomposeOutput(const COutPoint& output, const interfaces::WalletTxOut& out);
-
+    static std::vector<KernelRecord> decomposeOutput(const interfaces::WalletTx& wtx);
 
     uint256 hash;
     uint32_t n;

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -8,9 +8,6 @@
 /* Milliseconds between model updates */
 static const int MODEL_UPDATE_DELAY = 250;
 
-/* Milliseconds between mintingtablemodel updates */
-static const int MODEL_MINTING_UPDATE_DELAY = 1000;
-
 /* AskPassphraseDialog -- Maximum passphrase length */
 static const int MAX_PASSPHRASE_SIZE = 1024;
 

--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -392,7 +392,7 @@ MintingTableModel::MintingTableModel(const PlatformStyle *_platformStyle, Wallet
 
     QTimer *timer = new QTimer(this);
     connect(timer, SIGNAL(timeout()), this, SLOT(updateAge()));
-    timer->start(MODEL_MINTING_UPDATE_DELAY);
+    timer->start(MODEL_UPDATE_DELAY);
 
     connect(walletModel->getOptionsModel(), SIGNAL(displayUnitChanged(int)), this, SLOT(updateDisplayUnit()));
 }

--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -117,105 +117,6 @@ public:
         }
         
 printf("(refreshWallet) size %d\n", cachedWallet.size());
-    
-//        // delete changed hash
-//        while(delQueue.size() > 0)
-//        {
-//            std::pair<uint256, uint32_t> pair = delQueue[0];
-//            uint256 hash = pair.first;
-//            uint32_t n = pair.second;
-//std::cout << hash.ToString() << "-" << n << "\n";
-//            
-//            for(int i = 0; i < cachedWallet.size(); i++){
-//                if(cachedWallet[i].hash == hash && cachedWallet[i].n == n){
-//std::cout << "found at " << i << "\n";
-//                    parent->beginRemoveRows(QModelIndex(), i, i);
-//                    cachedWallet.removeAt(i);
-//                    parent->endRemoveRows();
-//                    break;
-//                }
-//                else{
-//std::cout << "no match (" << cachedWallet[i].getTxID() << "-" << cachedWallet[i].n << ")\n";
-//                }
-//            }
-//            
-//            delQueue.removeAt(0);
-//        }
-        
-        
-        // 
-//        while(addQueue.size() > 0)
-//        {
-//            const KernelRecord& kr = addQueue[0]; // FIFO
-//
-//            QList<KernelRecord>::iterator lower = qLowerBound(
-//                cachedWallet.begin(), cachedWallet.end(), kr, TxLessThan());
-//            int lowerIndex = (lower - cachedWallet.begin());
-//
-//            parent->beginInsertRows(QModelIndex(), lowerIndex, lowerIndex);
-//            cachedWallet.insert(lowerIndex, kr);
-//            parent->endInsertRows();
-//            
-//            addQueue.removeAt(0);
-//        }
-
-return;
-
-/*
-        // Make mask
-        QList<bool> mask;
-        for(int i = 0; i < cachedWallet.size(); i++)
-        {
-            mask.append(false);
-        }
-        
-        // Update and add records
-        for (const auto& coins : wallet.listCoins())
-        {
-            for (const auto& outpair : coins.second)
-            {
-                const COutPoint& output = std::get<0>(outpair);
-                const interfaces::WalletTxOut& out = std::get<1>(outpair);
-                std::vector<KernelRecord> txList = KernelRecord::decomposeOutput(output, out);
-                if(KernelRecord::showTransaction())
-                {
-
-                    for(const KernelRecord& kr : txList)
-                    {
-                        QList<KernelRecord>::iterator lower = qLowerBound(
-                            cachedWallet.begin(), cachedWallet.end(), kr, TxLessThan());
-                        QList<KernelRecord>::iterator upper = qUpperBound(
-                            cachedWallet.begin(), cachedWallet.end(), kr, TxLessThan());
-                        int lowerIndex = (lower - cachedWallet.begin());
-                        bool inModel = (lower != upper);
-
-                        if(inModel)
-                        {
-                            cachedWallet.replace(lowerIndex, kr);
-                            mask.replace(lowerIndex, true);
-                        }
-                        else
-                        {
-                            parent->beginInsertRows(QModelIndex(), lowerIndex, lowerIndex);
-                            cachedWallet.insert(lowerIndex, kr);
-                            mask.insert(lowerIndex, true);
-                            parent->endInsertRows();
-                        }
-                    }
-                }
-            }
-        }
-        // Delete old records
-        for(int i = 0; i < mask.size(); i++)
-        {
-            if(mask.at(i) == false)
-            {
-                parent->beginRemoveRows(QModelIndex(), i, i);
-                cachedWallet.removeAt(i);
-                parent->endRemoveRows();
-            }
-        }
-*/
     }
     
     void procEvent(uint256 hash, int status)
@@ -385,17 +286,6 @@ MintingTableModel::MintingTableModel(const PlatformStyle *_platformStyle, Wallet
     for (const auto& wtx : wtxs)
     {
         priv->procEvent(wtx.tx->GetHash(), CT_NEW);
-//        for(const KernelRecord& kr : KernelRecord::decomposeOutput(wtx)){
-//            priv->addQueue.append(kr);
-
-//            QList<KernelRecord>::iterator lower = qLowerBound(
-//                priv->cachedWallet.begin(), priv->cachedWallet.end(), kr, TxLessThan());
-//            int lowerIndex = (lower - priv->cachedWallet.begin());
-//
-//            beginInsertRows(QModelIndex(), lowerIndex, lowerIndex);
-//            priv->cachedWallet.insert(lowerIndex, kr);
-//            endInsertRows();
-//        }
     }
 
     subscribeToCoreSignals();
@@ -421,11 +311,8 @@ void MintingTableModel::updateTransaction(const QString &hash, int status, bool 
 
     // CT_NEW -> add
     // !showTransaction -> delete
-    // CT_UPDATED && inModel -> nothing to do
-    // CT_UPDATED && !inModel -> add
+    // CT_UPDATED -> nothing to do
     priv->procQueue.append(std::make_pair(updated, showTransaction ? status : CT_DELETED));
-//    priv->refreshWallet(walletModel->wallet());
-//    mintingProxyModel->invalidate(); // Force deletion of empty rows
 }
 
 void MintingTableModel::updateAge()

--- a/src/qt/mintingtablemodel.cpp
+++ b/src/qt/mintingtablemodel.cpp
@@ -115,14 +115,10 @@ public:
             procEvent(pair.first, pair.second);
             procQueue.removeAt(0);
         }
-        
-printf("(refreshWallet) size %d\n", cachedWallet.size());
     }
     
     void procEvent(uint256 hash, int status)
     {
-//printf("(procEvent) proc %s : %d\n", hash.ToString().c_str(), status);
-
         // Find bounds of this transaction in model
         QList<KernelRecord>::iterator lower = qLowerBound(
             cachedWallet.begin(), cachedWallet.end(), hash, TxLessThan());
@@ -147,7 +143,6 @@ printf("(refreshWallet) size %d\n", cachedWallet.size());
             // requeue if the transaction is coinbase and immature
             if(tx_status.is_coinbase && tx_status.blocks_to_maturity > 0)
             {
-//printf("(procEvent) requeue : %s (depth = %d)\n", hash.ToString().c_str(), tx_status.depth_in_main_chain);
                 procQueue.append(std::make_pair(hash, status));
                 return;
             }
@@ -161,11 +156,9 @@ printf("(refreshWallet) size %d\n", cachedWallet.size());
                 {
                     uint256 phash = ins[i].prevout.hash;
                     uint32_t n = ins[i].prevout.n;
-//printf("(procEvent) delRow %s : %d\n", phash.ToString().c_str(), n);
                     
                     for(int i = 0; i < cachedWallet.size(); i++){
                         if(cachedWallet[i].hash == phash && cachedWallet[i].n == n){
-//printf("(procEvent) delRow found at %d\n", i);
                             parent->beginRemoveRows(QModelIndex(), i, i);
                             cachedWallet.removeAt(i);
                             parent->endRemoveRows();
@@ -179,8 +172,6 @@ printf("(refreshWallet) size %d\n", cachedWallet.size());
             int offsetLower = 0;
             for(const KernelRecord& kr : KernelRecord::decomposeOutput(wtx))
             {
-//printf("%s\t%d\n", kr.hash.ToString().c_str(), kr.n);
-//printf("(procEvent) addRow %d : %ld\n", kr.n, kr.nValue);
                 if(parent->walletModel->wallet().isSpent(kr.hash, kr.n)) // spent
                 {
                     continue;
@@ -199,7 +190,6 @@ printf("(refreshWallet) size %d\n", cachedWallet.size());
         else if(status == CT_DELETED)
         {
             // this status is not thrown
-//printf("(procEvent) delete tx %s\n", hash.ToString().c_str());
             parent->beginRemoveRows(QModelIndex(), lowerIndex, upperIndex - 1);
             for(int i = lowerIndex; i < upperIndex; i++)
             {
@@ -224,7 +214,6 @@ printf("(refreshWallet) size %d\n", cachedWallet.size());
                     
                     if(prev_lower == prev_upper) // not in model
                     {
-//printf("(procEvent) reviveRow %s : %d\n", kr.hash.ToString().c_str(), kr.n);
                         parent->beginInsertRows(QModelIndex(), prev_lowerIndex, prev_lowerIndex);
                         cachedWallet.insert(prev_lowerIndex, kr);
                         parent->endInsertRows();

--- a/src/qt/mintingtablemodel.h
+++ b/src/qt/mintingtablemodel.h
@@ -47,6 +47,7 @@ public:
 
 private:
     WalletModel *walletModel;
+    std::unique_ptr<interfaces::Handler> m_handler_transaction_changed;
     QStringList columns;
     int mintingInterval;
     MintingTablePriv *priv;
@@ -63,6 +64,9 @@ private:
     QString formatTxBalance(const KernelRecord *wtx) const;
     QString formatTxCoinDay(const KernelRecord *wtx) const;
     QString formatTxPoSReward(KernelRecord *wtx) const;
+
+    void subscribeToCoreSignals();
+    void unsubscribeFromCoreSignals();
 
 public Q_SLOTS:
     void updateTransaction(const QString &hash, int status, bool showTransaction);


### PR DESCRIPTION
- 起動時にウォレットのTXを見てすべてCT_NEWと同じ処理をする
- それ以降はウォレットから新規TX、更新の通知を受け取る（が、更新は何もしない）
---
- CT_NEWがきたら、outの分は表に追加、inの分は表から削除する
- ただしCoinbaseは101承認ないと追加しない（再度キューに積む）
- キューはrefreshごとに1つだけ処理される
---
- コメントが書きかけコードいっぱいなのは整理してないから
- 動作確認しながら整理して終わりになりたい